### PR TITLE
🌐 i18n(contributions): add GitHub usernames for contributors

### DIFF
--- a/site/data/contributions/the-kanban-guide.yml
+++ b/site/data/contributions/the-kanban-guide.yml
@@ -38,6 +38,7 @@
   weight: 1
 
 - name: Julia Wester
+  githubUsername: julia-wester
   contributions:
     - "2020.7"
     - "2020.12"
@@ -82,11 +83,12 @@
   role: contributor
 
 - name: Tom Gilb
+  githubUsername: Tom-Gilb
   contributions:
     - "2020.12"
     - "2025.5"
   weight: 100
-  founder: true
+  founder: true``
   role: contributor
 
 - name: Steve Tendon


### PR DESCRIPTION
- include GitHub usernames for Julia Wester and Tom Gilb in the Kanban Guide contributions data
- ensure consistency and traceability for contributor records