### PR TITLE
🌐 i18n(locale): correct typos in Kanban guides introduction

### DIFF
--- a/site/i18n/en.yaml
+++ b/site/i18n/en.yaml
@@ -54,7 +54,7 @@
   translation: "Engage with the community, share your insights, and help shape the future of the Kanban Guides. Your contributions are invaluable in making these guides comprehensive resources for Kanban practitioners."
 
 - id: guides_intro_text
-  translation: "Learn what Kanban is and how to apply it to optimise the flow of value through a process. This is your comprehensive resource for Kanban knowledge and practices. Kanban Guides is the home of the Open Guide to Kanban, and The Kanban Guide. It is a free, community-driven reference for applying Kanban in knowledge work. The guides define the core practices, and metrics  necessary to improve flow, optimise value delivery, and enhance team sustainability. These guides support scalable Kanban adoptions across diverse industries and complement other agile, lean, and flow-based approaches."
+  translation: "Learn what Kanban is and how to apply it to optimise the flow of value through a process. This is your comprehensive resource for Kanban knowledge and practices. Kanban Guides is the home of the The Kanban Guide, adn the Open Guide to Kanban. It is a free, community-driven reference for applying Kanban in knowledge work. The guides define the core practices, and metrics  necessary to improve flow, optimise value delivery, and enhance team sustainability. These guides support scalable Kanban adoptions across diverse industries and complement other agile, lean, and flow-based approaches."
 
 - id: download_title
   translation: "Download {{ .Site.Title }}"


### PR DESCRIPTION
- fix typo in "The Kanban Guide" and "adn" to "and"
