### PR TITLE
Update hugoguides module

### DIFF
--- a/site/go.mod
+++ b/site/go.mod
@@ -2,4 +2,4 @@ module github.com/ScrumGuides/ScrumGuide-ExpansionPack/site
 
 go 1.24.5
 
-require github.com/nkdAgility/HugoGuides/module v0.6.6 // indirect
+require github.com/nkdAgility/HugoGuides/module v0.6.7 // indirect

--- a/site/go.sum
+++ b/site/go.sum
@@ -4,3 +4,5 @@ github.com/nkdAgility/HugoGuides/module v0.6.5 h1:8un1EHMWXCwRoqwOuwr8iRv85RhbRm
 github.com/nkdAgility/HugoGuides/module v0.6.5/go.mod h1:VGUy7t0I5Ba4FWVFpuBzVI1RN/cOBvcWSeYGsAj37tE=
 github.com/nkdAgility/HugoGuides/module v0.6.6 h1:VVJ6BjOgwi5EODd0ldtNRLfHosuhg4bJrt3Hbb3tiuQ=
 github.com/nkdAgility/HugoGuides/module v0.6.6/go.mod h1:VGUy7t0I5Ba4FWVFpuBzVI1RN/cOBvcWSeYGsAj37tE=
+github.com/nkdAgility/HugoGuides/module v0.6.7 h1:vYDp0gonPe2SUbKXo6OzIJTDKv1eNeiqR4zhGtv0f/Q=
+github.com/nkdAgility/HugoGuides/module v0.6.7/go.mod h1:VGUy7t0I5Ba4FWVFpuBzVI1RN/cOBvcWSeYGsAj37tE=


### PR DESCRIPTION
This pull request updates the `go.mod` file in the `site` module to use a newer version of the `github.com/nkdAgility/HugoGuides/module` dependency. The version has been incremented from `v0.6.6` to `v0.6.7` to include the latest changes and improvements.

* [`site/go.mod`](diffhunk://#diff-8b720a6c52c203c73c71c632d2087b411c532e506a86830eed851baaf96b61d1L5-R5): Updated the `github.com/nkdAgility/HugoGuides/module` dependency from version `v0.6.6` to `v0.6.7`.