### PR TITLE
Update to 0.7.1 of hugo guide

### DIFF
--- a/site/go.mod
+++ b/site/go.mod
@@ -2,4 +2,4 @@ module github.com/ScrumGuides/ScrumGuide-ExpansionPack/site
 
 go 1.24.5
 
-require github.com/nkdAgility/HugoGuides/module v0.7.0 // indirect
+require github.com/nkdAgility/HugoGuides/module v0.7.1 // indirect

--- a/site/go.sum
+++ b/site/go.sum
@@ -10,3 +10,5 @@ github.com/nkdAgility/HugoGuides/module v0.6.8 h1:9Y4fJ/+6cfx7qEOnSleQPb7oldcseR
 github.com/nkdAgility/HugoGuides/module v0.6.8/go.mod h1:VGUy7t0I5Ba4FWVFpuBzVI1RN/cOBvcWSeYGsAj37tE=
 github.com/nkdAgility/HugoGuides/module v0.7.0 h1:xPbwTijbm3ctwC1ubGDdTM3RUimpvxrZkXJMtTfl6Co=
 github.com/nkdAgility/HugoGuides/module v0.7.0/go.mod h1:VGUy7t0I5Ba4FWVFpuBzVI1RN/cOBvcWSeYGsAj37tE=
+github.com/nkdAgility/HugoGuides/module v0.7.1 h1:D4zzrmVO22sfGHvbq7AzoRiVUgodcMOzC1DFp2UGGRA=
+github.com/nkdAgility/HugoGuides/module v0.7.1/go.mod h1:VGUy7t0I5Ba4FWVFpuBzVI1RN/cOBvcWSeYGsAj37tE=

--- a/site/i18n/en.yaml
+++ b/site/i18n/en.yaml
@@ -315,6 +315,18 @@
 - id: guide_back_to_home
   translation: "← Back to Home"
 
+- id: guide_historical_version_notice_title
+  translation: "Historical Version Notice:"
+
+- id: guide_historical_version_notice_text
+  translation: "You are viewing version {{ .CurrentVersion }} of this guide."
+
+- id: guide_historical_version_notice_link
+  translation: "View the latest version ({{ .LatestVersion }})"
+
+- id: guide_historical_version_notice_suffix
+  translation: "for the most up-to-date information."
+
 - id: not_sure_which_to_use_title
   translation: "Not Sure Which to Use?"
 

--- a/site/i18n/es-419.yaml
+++ b/site/i18n/es-419.yaml
@@ -312,6 +312,18 @@
 - id: guide_back_to_home
   translation: "← Volver al Inicio"
 
+- id: guide_historical_version_notice_title
+  translation: "Aviso de Versión Histórica:"
+
+- id: guide_historical_version_notice_text
+  translation: "Estás viendo la versión {{ .CurrentVersion }} de esta guía."
+
+- id: guide_historical_version_notice_link
+  translation: "Ver la versión más reciente ({{ .LatestVersion }})"
+
+- id: guide_historical_version_notice_suffix
+  translation: "para obtener la información más actualizada."
+
 - id: not_sure_which_to_use_title
   translation: "¿No estás seguro cuál usar?"
 

--- a/site/i18n/min.yaml
+++ b/site/i18n/min.yaml
@@ -315,6 +315,18 @@
 - id: guide_back_to_home
   translation: "← Backy to Bello House"
 
+- id: guide_historical_version_notice_title
+  translation: "Old Timey Booky Warning:"
+
+- id: guide_historical_version_notice_text
+  translation: "You peeky at old version {{ .CurrentVersion }} of dis booky."
+
+- id: guide_historical_version_notice_link
+  translation: "Looky newest booky ({{ .LatestVersion }})"
+
+- id: guide_historical_version_notice_suffix
+  translation: "for fresh-fresh banana info."
+
 - id: not_sure_which_to_use_title
   translation: "Banana Confuse? Use Which??"
 


### PR DESCRIPTION
This pull request updates a dependency in the `go.mod` file and introduces new translations for a historical version notice across multiple languages. The changes ensure the site reflects accurate versioning information and supports internationalization.

### Dependency Update:
* Updated `github.com/nkdAgility/HugoGuides/module` dependency from version `v0.7.0` to `v0.7.1` in `site/go.mod`. This likely includes bug fixes or minor improvements.

### Internationalization Enhancements:
* Added new translation keys for a historical version notice in the following files:
  - [`site/i18n/en.yaml`](diffhunk://#diff-edf3e5566d707f973c44aac01937c9f60bd149c08df4495aebe2d77bc1ffb494R318-R329): Added English translations for the notice title, text, link, and suffix.
  - [`site/i18n/es-419.yaml`](diffhunk://#diff-b9a2ec3afeb37b4fae174c819b37ee701fd69143361244c2fcf3f34d6cfde95cR315-R326): Added Spanish translations for the same notice elements.
  - [`site/i18n/min.yaml`](diffhunk://#diff-128feb86e84a72ad99bff65ed6609d07a09cdbd12cda620f8e25c06aa076c5c8R318-R329): Added whimsical "Minion"-style translations for the notice elements.