### PR TITLE
Add translation preview notes and enable Japanese translations

### DIFF
--- a/site/content/open-guide-to-kanban/2025.7/index.ja.md
+++ b/site/content/open-guide-to-kanban/2025.7/index.ja.md
@@ -68,6 +68,7 @@ sitemap:
   priority: 1.0
 aliases:
   - /open-guide-to-kanban/latest/
+translationDraft: true
 ---
 
 <!-- This work, Open Guide to Kanban, is an adaptation of the [Kanban Guide (May 2025 version)](https://kanbanguides.org/history/kanban-guide-2025/), which is licensed under the Creative Commons Attribution-ShareAlike 4.0 International License (CC BY-SA 4.0). The original guide is © 2019-2025 Orderly Disruption Limited, Daniel S. Vacanti, Inc. Changes were made to the original. Licensed under [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/). _Portions highlighted in italic are © 2025_ Orderly Disruption Limited, licensed under CC BY-SA 4.0. All other content is from © 2019-2025 Orderly Disruption Limited, Daniel S. Vacanti, Inc., also licensed under CC BY-SA 4.0. -->

--- a/site/content/open-guide-to-kanban/2025.7/index.ja.md
+++ b/site/content/open-guide-to-kanban/2025.7/index.ja.md
@@ -69,6 +69,13 @@ sitemap:
 aliases:
   - /open-guide-to-kanban/latest/
 translationDraft: true
+translators:
+- name: Tomoharu Nagasawa
+  githubUsername: tomoharunagasawa
+  url: https://www.linkedin.com/in/tnagasawa/
+  role: translator
+  founder: true
+  weight: 1
 ---
 
 <!-- This work, Open Guide to Kanban, is an adaptation of the [Kanban Guide (May 2025 version)](https://kanbanguides.org/history/kanban-guide-2025/), which is licensed under the Creative Commons Attribution-ShareAlike 4.0 International License (CC BY-SA 4.0). The original guide is © 2019-2025 Orderly Disruption Limited, Daniel S. Vacanti, Inc. Changes were made to the original. Licensed under [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/). _Portions highlighted in italic are © 2025_ Orderly Disruption Limited, licensed under CC BY-SA 4.0. All other content is from © 2019-2025 Orderly Disruption Limited, Daniel S. Vacanti, Inc., also licensed under CC BY-SA 4.0. -->

--- a/site/content/the-kanban-guide/2025.5/index.ja.md
+++ b/site/content/the-kanban-guide/2025.5/index.ja.md
@@ -29,6 +29,13 @@ guide_whatis: |
    本ガイドでは、いくつかの用語について特定の使い方を定めている。これらは既存の定義を置き換えることを意図したものではなく、本ガイドにおける用法を明確にするためのものである。
 aliases:
   - /the-kanban-guide/latest
+translators:
+- name: Tomoharu Nagasawa
+  githubUsername: tomoharunagasawa
+  url: https://www.linkedin.com/in/tnagasawa/
+  role: translator
+  founder: true
+  weight: 1
 ---
 
 <!-- ## Preface -->

--- a/site/go.mod
+++ b/site/go.mod
@@ -2,4 +2,4 @@ module github.com/ScrumGuides/ScrumGuide-ExpansionPack/site
 
 go 1.24.5
 
-require github.com/nkdAgility/HugoGuides/module v0.7.1 // indirect
+require github.com/nkdAgility/HugoGuides/module v0.7.2 // indirect

--- a/site/go.sum
+++ b/site/go.sum
@@ -12,3 +12,5 @@ github.com/nkdAgility/HugoGuides/module v0.7.0 h1:xPbwTijbm3ctwC1ubGDdTM3RUimpvx
 github.com/nkdAgility/HugoGuides/module v0.7.0/go.mod h1:VGUy7t0I5Ba4FWVFpuBzVI1RN/cOBvcWSeYGsAj37tE=
 github.com/nkdAgility/HugoGuides/module v0.7.1 h1:D4zzrmVO22sfGHvbq7AzoRiVUgodcMOzC1DFp2UGGRA=
 github.com/nkdAgility/HugoGuides/module v0.7.1/go.mod h1:VGUy7t0I5Ba4FWVFpuBzVI1RN/cOBvcWSeYGsAj37tE=
+github.com/nkdAgility/HugoGuides/module v0.7.2 h1:eKkwj7p2r9+CpR7axltRWOX5KPJlhN3UQcVmhsOr8Zc=
+github.com/nkdAgility/HugoGuides/module v0.7.2/go.mod h1:VGUy7t0I5Ba4FWVFpuBzVI1RN/cOBvcWSeYGsAj37tE=

--- a/site/hugo.production.yaml
+++ b/site/hugo.production.yaml
@@ -17,5 +17,5 @@ languages:
   es-419:
     disabled: true
   ja:
-    disabled: true
+    disabled: false
 

--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -53,9 +53,9 @@ params:
   og_image: /images/open-guide-to-kanban-logo-512.png
   siteProdUrl: https://kanbanguides.org
   supportEmail: support@kanbanguides.org
-  githubUrl: https://github.com/KanbanGuides/KanbanGuides
+  githubUrl: https://github.com/KanbanGuides/KanbanGuides/
   previewSiteUrl: https://red-pond-0d8225910-preview.centralus.2.azurestaticapps.net/
-  productionSiteUrl: https://kanbanguides.org/
+  productionSiteUrl: https://kanbanguides.org
   brand:
     bg_colour: '#135289'
   logo_image: "/images/kanban-guides-logo-dark.png" # URL to the site logo image

--- a/site/i18n/en.yaml
+++ b/site/i18n/en.yaml
@@ -23,6 +23,15 @@
 - id: translations_button
   translation: "View Translations"
 
+- id: guide_translation_preview_note
+  translation: "Translation Preview:"
+
+- id: guide_translation_preview_message
+  translation: "This guide is a translation preview and may not be fully complete or accurate. Please help us review and improve it, join the discussion."
+  
+- id: guide_preview_link
+  translation: "Help us review this translation"
+
 - id: history_title
   translation: "History"
 

--- a/site/i18n/en.yaml
+++ b/site/i18n/en.yaml
@@ -20,6 +20,9 @@
 - id: translations_description
   translation: "Access this guide in multiple languages and help with translations."
 
+- id: translators_label
+  translation: "Translators"
+
 - id: translations_button
   translation: "View Translations"
 

--- a/site/i18n/es-419.yaml
+++ b/site/i18n/es-419.yaml
@@ -20,8 +20,19 @@
 - id: translations_description
   translation: "Accede a esta guía en múltiples idiomas y ayuda con las traducciones."
 
+
 - id: translations_button
   translation: "Ver Traducciones"
+
+- id: guide_translation_preview_note
+  translation: "Vista previa de la traducción:"
+
+- id: guide_translation_preview_message
+  translation: "Esta guía es una vista previa de la traducción y puede no estar completamente terminada o ser precisa. Por favor, ayúdanos a revisarla y mejorarla, únete a la conversación."
+
+- id: guide_preview_link
+  translation: "Ayúdanos a revisar esta traducción"
+
 
 - id: history_title
   translation: "Historia"

--- a/site/i18n/es-419.yaml
+++ b/site/i18n/es-419.yaml
@@ -20,6 +20,8 @@
 - id: translations_description
   translation: "Accede a esta guía en múltiples idiomas y ayuda con las traducciones."
 
+- id: translators_label
+  translation: "Traductores"
 
 - id: translations_button
   translation: "Ver Traducciones"

--- a/site/i18n/ja.yaml
+++ b/site/i18n/ja.yaml
@@ -32,6 +32,16 @@
   # translation: "View Translations"
   translation: "翻訳版を閲覧する"
 
+- id: guide_translation_preview_note
+  translation: "翻訳プレビュー："
+
+- id: guide_translation_preview_message
+  translation: "このガイドは翻訳のプレビューであり、完全または正確でない可能性があります。レビューと改善にご協力ください。議論に参加しましょう。"
+
+- id: guide_preview_link
+  translation: "この翻訳のレビューにご協力ください"
+
+
 - id: history_title
   # translation: "History"
   translation: "履歴"

--- a/site/i18n/ja.yaml
+++ b/site/i18n/ja.yaml
@@ -32,6 +32,9 @@
   # translation: "View Translations"
   translation: "翻訳版を閲覧する"
 
+- id: translators_label
+  translation: "翻訳者"
+
 - id: guide_translation_preview_note
   translation: "翻訳プレビュー："
 

--- a/site/i18n/min.yaml
+++ b/site/i18n/min.yaml
@@ -23,6 +23,16 @@
 - id: translations_button
   translation: "Peek-a-boo Languages"
 
+- id: guide_translation_preview_note
+  translation: "Banana Peek-a-boo:"
+
+- id: guide_translation_preview_message
+  translation: "Dis guide iz banana peek, no all done-done or right-right. You help? Join da blabla!"
+
+- id: guide_preview_link
+  translation: "You help check banana words?"
+
+
 - id: history_title
   translation: "Old Timey Time"
 

--- a/site/i18n/min.yaml
+++ b/site/i18n/min.yaml
@@ -23,6 +23,9 @@
 - id: translations_button
   translation: "Peek-a-boo Languages"
 
+- id: translators_label
+  translation: "talky-translaters"
+
 - id: guide_translation_preview_note
   translation: "Banana Peek-a-boo:"
 


### PR DESCRIPTION
This pull request introduces changes to enable and support a Japanese translation preview for the Open Guide to Kanban. The most important updates include enabling the Japanese language in the configuration, adding translation preview metadata and messages, and updating dependencies for the site.

### Translation Support Enhancements:

* Enabled the Japanese language (`ja`) in the `site/hugo.production.yaml` configuration file, allowing the guide to be displayed in Japanese.
* Added a `translationDraft` metadata field to the Japanese guide file (`site/content/open-guide-to-kanban/2025.7/index.ja.md`) to indicate that it is a draft translation.

### Translation Preview Messaging:

* Added new translation keys in the `site/i18n` files (`en.yaml`, `es-419.yaml`, `ja.yaml`, and `min.yaml`) to display messages about the translation preview, encouraging users to review and improve the translations. [[1]](diffhunk://#diff-edf3e5566d707f973c44aac01937c9f60bd149c08df4495aebe2d77bc1ffb494R26-R34) [[2]](diffhunk://#diff-b9a2ec3afeb37b4fae174c819b37ee701fd69143361244c2fcf3f34d6cfde95cR23-R36) [[3]](diffhunk://#diff-4be00422bdf0a3eb4a5844d6dfbae9f6fbeefec00b0657a5439699af6151f693R35-R44) [[4]](diffhunk://#diff-128feb86e84a72ad99bff65ed6609d07a09cdbd12cda620f8e25c06aa076c5c8R26-R35)

### Dependency Update:

* Updated the `github.com/nkdAgility/HugoGuides/module` dependency from version `v0.7.1` to `v0.7.2` in the `site/go.mod` file to ensure compatibility and access to the latest features.