### PR TITLE
Update HugoGuides module to v0.7.3 in go.mod and go.sum

### DIFF
--- a/site/go.mod
+++ b/site/go.mod
@@ -2,4 +2,4 @@ module github.com/KanbanGuides/KanbanGuides/site
 
 go 1.24.5
 
-require github.com/nkdAgility/HugoGuides/module v0.7.2 // indirect
+require github.com/nkdAgility/HugoGuides/module v0.7.3 // indirect

--- a/site/go.sum
+++ b/site/go.sum
@@ -14,3 +14,5 @@ github.com/nkdAgility/HugoGuides/module v0.7.1 h1:D4zzrmVO22sfGHvbq7AzoRiVUgodcM
 github.com/nkdAgility/HugoGuides/module v0.7.1/go.mod h1:VGUy7t0I5Ba4FWVFpuBzVI1RN/cOBvcWSeYGsAj37tE=
 github.com/nkdAgility/HugoGuides/module v0.7.2 h1:eKkwj7p2r9+CpR7axltRWOX5KPJlhN3UQcVmhsOr8Zc=
 github.com/nkdAgility/HugoGuides/module v0.7.2/go.mod h1:VGUy7t0I5Ba4FWVFpuBzVI1RN/cOBvcWSeYGsAj37tE=
+github.com/nkdAgility/HugoGuides/module v0.7.3 h1:FB0JQzOlfXfwR6fcLhCk+n2uGsbWW+ODaaKzyz9N51g=
+github.com/nkdAgility/HugoGuides/module v0.7.3/go.mod h1:VGUy7t0I5Ba4FWVFpuBzVI1RN/cOBvcWSeYGsAj37tE=


### PR DESCRIPTION
This pull request updates the version of the `github.com/nkdAgility/HugoGuides/module` dependency in the `site/go.mod` file to ensure the project uses the latest available features and bug fixes.

* Dependency update:
  * Upgraded `github.com/nkdAgility/HugoGuides/module` from version `v0.7.2` to `v0.7.3` in `site/go.mod`.